### PR TITLE
New Zealand public holidays mondayised

### DIFF
--- a/data/nz.yaml
+++ b/data/nz.yaml
@@ -46,6 +46,7 @@ months:
   - name: Waitangi Day
     regions: [nz]
     mday: 6
+    observed: to_monday_if_weekend
   3:
   - name: Otago Anniversary Day
     regions: [nz_ot]
@@ -59,6 +60,7 @@ months:
   - name: ANZAC Day
     regions: [nz]
     mday: 25
+    observed: to_monday_if_weekend
   6:
   - name: Queen's Birthday
     regions: [nz]


### PR DESCRIPTION
NZ passed a bill in 2013 which makes the following Monday a public holiday if Anzac or Waitangi day occur on the weekend. [1]

[1] http://www.3news.co.nz/politics/extra-public-holidays-voted-in-2013041719
